### PR TITLE
7.0 Use branch specified png badge for coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/OCA/sale-reporting.svg?branch=7.0)](https://travis-ci.org/OCA/sale-reporting)
-[![Coverage Status](https://img.shields.io/coveralls/OCA/sale-reporting.svg)](https://coveralls.io/r/OCA/sale-reporting?branch=7.0)
+[![Coverage Status](https://coveralls.io/repos/OCA/sale-reporting/badge.png?branch=7.0)](https://coveralls.io/r/OCA/sale-reporting?branch=7.0)
 
 
 


### PR DESCRIPTION
It would seem sale-reporting is not yet enabled with coverage.

An Admin will have to see to this.
