### PR TITLE
[ADD] sale_reporting_weight

### DIFF
--- a/sale_reporting_weight/README.rst
+++ b/sale_reporting_weight/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================
+Weights in the sales analysis view
+==================================
+
+This module adds the measure "Weight" in the sales analysis view. This is
+caught from 2 possible sources:
+
+* If the UoM of the product is one of the category "Weight", the value is taken
+  from the ordered quantity.
+* If the UoM of the product is another, then the weight is taken from the
+  weight field of the product multiply by the ordered quantity.
+
+Usage
+=====
+
+#. Go to *Sales > Reports > Sales*.
+#. Add the "Weight" measure from your "Measures" dropdown in your analysis.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/148/9.0
+
+Known issues / Roadmap
+======================
+
+* The weight quantity is expressed in the unit of measure of the product,
+  so if you have several weight UoMs across your products, the global sum won't
+  make sense.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_reporting_weight/__init__.py
+++ b/sale_reporting_weight/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import reports

--- a/sale_reporting_weight/__openerp__.py
+++ b/sale_reporting_weight/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Weights in the sales analysis view',
+    'version': '9.0.1.0.0',
+    'author': 'Tecnativa,'
+              'Odoo Community Association (OCA)',
+    'category': 'Inventory, Logistics, Warehousing',
+    'license': 'AGPL-3',
+    'website': 'https://www.tecnativa.com',
+    'depends': [
+        'sale',
+    ],
+    'installable': True,
+}

--- a/sale_reporting_weight/reports/__init__.py
+++ b/sale_reporting_weight/reports/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import sale_report

--- a/sale_reporting_weight/reports/sale_report.py
+++ b/sale_reporting_weight/reports/sale_report.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import fields, models
+import openerp.addons.decimal_precision as dp
+
+
+class SaleReport(models.Model):
+    _inherit = "sale.report"
+
+    weight = fields.Float(digits=dp.get_precision('Stock Weight'))
+
+    def _select(self):
+        select_str = super(SaleReport, self)._select()
+        select_str += """
+            , CASE
+                WHEN u.category_id = imd.res_id
+                THEN SUM(l.product_uom_qty / u.factor * u2.factor)
+                ELSE SUM(p.weight * l.product_uom_qty / u.factor * u2.factor)
+            END AS weight
+            """
+        return select_str
+
+    def _from(self):
+        from_str = super(SaleReport, self)._from()
+        from_str += """
+            JOIN ir_model_data imd
+                ON (imd.module = 'product' AND
+                    imd.name = 'product_uom_categ_kgm')
+            """
+        return from_str
+
+    def _group_by(self):
+        group_by_str = super(SaleReport, self)._group_by()
+        group_by_str += ", p.weight, u.category_id, imd.res_id"
+        return group_by_str


### PR DESCRIPTION
Weights in the sales analysis view
==================================

This module adds the measure "Weight" in the sales analysis view. This is caught from 2 possible sources:

* If the UoM of the product is one of the category "Weight", the value is taken from the ordered quantity.
* If the UoM of the product is another, then the weight is taken from the weight field of the product multiply by the ordered quantity.

Usage
=====

* Go to *Sales > Reports > Sales*.
* Add the "Weight" measure from your "Measures" dropdown in your analysis.

Known issues / Roadmap
======================

* The weight quantity is expressed in the unit of measure of the product, so if you have several weight UoMs across your products, the global sum won't make sense.