### PR TITLE
[IMP] sale_comment_template: add partner template

### DIFF
--- a/sale_comment_template/README.rst
+++ b/sale_comment_template/README.rst
@@ -76,7 +76,8 @@ Contributors
 * Xavier Jimenez <xavier.jimenez@qubiq.es>
 * `Tecnativa <https://www.tecnativa.com>`_:
 
-  * Pedro M. Baeza
+  * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+  * Vicent Cubells <vicent.cubells@tecnativa.com>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/sale_comment_template/__manifest__.py
+++ b/sale_comment_template/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Sale Comments",
     "summary": "Comments texts templates on Sale documents",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "depends": [
         "sale",
         "account_invoice_comment_template",

--- a/sale_comment_template/i18n/es.po
+++ b/sale_comment_template/i18n/es.po
@@ -18,55 +18,55 @@ msgstr ""
 #. module: sale_comment_template
 #: model:ir.model.fields,field_description:sale_comment_template.field_sale_order_note2
 msgid "Bottom Comment"
-msgstr ""
+msgstr "Comentario inferior"
 
 #. module: sale_comment_template
 #: model:ir.model.fields,field_description:sale_comment_template.field_sale_order_comment_template2_id
 msgid "Bottom Comment Template"
-msgstr ""
+msgstr "Plantilla del comentario inferior"
 
 #. module: sale_comment_template
 #: model:ir.ui.view,arch_db:sale_comment_template.sale_order_form_add_comment
 msgid "Bottom Comments"
-msgstr ""
+msgstr "Comentarios de la parte inferior"
 
 #. module: sale_comment_template
 #: model:ir.ui.view,arch_db:sale_comment_template.sale_order_form_add_comment
 msgid "Comments"
-msgstr ""
+msgstr "Comentarios"
 
 #. module: sale_comment_template
 #: model:ir.ui.menu,name:sale_comment_template.menu_base_comment_template_sale
 msgid "Document Comments"
-msgstr ""
+msgstr "Comentarios del documentos"
 
 #. module: sale_comment_template
 #: model:ir.ui.view,arch_db:sale_comment_template.sale_order_form_add_comment
 msgid "Load a template"
-msgstr ""
+msgstr "Cargar una plantialla"
 
 #. module: sale_comment_template
 #: model:ir.model,name:sale_comment_template.model_sale_order
 msgid "Quotation"
-msgstr ""
+msgstr "Presupuesto"
 
 #. module: sale_comment_template
 #: model:ir.ui.view,arch_db:sale_comment_template.sale_order_form_add_comment
 msgid "The comments will be displayed on the printed document. You can load a predefined template, write your own text or load a template and then modify it only for this document."
-msgstr ""
+msgstr "Los comentarios se mostrarán en los documentos impresos. Puede cargar una plantilla pedefinida, escribir su propio texto o cargar una plantilla y modificarla para este documento."
 
 #. module: sale_comment_template
 #: model:ir.model.fields,field_description:sale_comment_template.field_sale_order_note1
 msgid "Top Comment"
-msgstr ""
+msgstr "Comentario superior"
 
 #. module: sale_comment_template
 #: model:ir.model.fields,field_description:sale_comment_template.field_sale_order_comment_template1_id
 msgid "Top Comment Template"
-msgstr ""
+msgstr "Plantilla del comentario superior"
 
 #. module: sale_comment_template
 #: model:ir.ui.view,arch_db:sale_comment_template.sale_order_form_add_comment
 msgid "Top Comments"
-msgstr ""
+msgstr "Comentarios de la parte superior"
 

--- a/sale_comment_template/models/sale_order.py
+++ b/sale_comment_template/models/sale_order.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2014 Nicolas Bessi (Camptocamp SA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -38,3 +38,12 @@ class SaleOrder(models.Model):
             'note2': self.note2,
         })
         return values
+
+    @api.onchange('partner_id')
+    def onchange_partner_id_sale_comment(self):
+        if self.partner_id:
+            comment_template = self.partner_id.comment_template_id
+            if comment_template.position == 'before_lines':
+                self.comment_template1_id = comment_template
+            elif comment_template.position == 'after_lines':
+                self.comment_template2_id = comment_template

--- a/sale_comment_template/readme/CONTRIBUTORS.rst
+++ b/sale_comment_template/readme/CONTRIBUTORS.rst
@@ -4,6 +4,7 @@
 * Xavier Jimenez <xavier.jimenez@qubiq.es>
 * `Tecnativa <https://www.tecnativa.com>`_:
 
-  * Pedro M. Baeza
+  * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+  * Vicent Cubells <vicent.cubells@tecnativa.com>
 
 Do not contact contributors directly about support or help with technical issues.

--- a/sale_comment_template/static/description/index.html
+++ b/sale_comment_template/static/description/index.html
@@ -420,7 +420,8 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;agilebg.com">simone.rubino&#64;agilebg.com</a>&gt;</li>
 <li>Xavier Jimenez &lt;<a class="reference external" href="mailto:xavier.jimenez&#64;qubiq.es">xavier.jimenez&#64;qubiq.es</a>&gt;</li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
-<li>Pedro M. Baeza</li>
+<li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;tecnativa.com">pedro.baeza&#64;tecnativa.com</a>&gt;</li>
+<li>Vicent Cubells &lt;<a class="reference external" href="mailto:vicent.cubells&#64;tecnativa.com">vicent.cubells&#64;tecnativa.com</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/sale_comment_template/tests/test_sale_order_report.py
+++ b/sale_comment_template/tests/test_sale_order_report.py
@@ -11,6 +11,9 @@ class TestAccountInvoiceReport(TransactionCase):
         self.base_comment_model = self.env['base.comment.template']
         self.before_comment = self._create_comment('before_lines')
         self.after_comment = self._create_comment('after_lines')
+        self.partner_id = self.env['res.partner'].create({
+            'name': 'Partner Test'
+        })
         self.sale_order = self.env.ref('sale.sale_order_7')
         self.sale_order.update({
             'comment_template1_id': self.before_comment.id,
@@ -44,3 +47,20 @@ class TestAccountInvoiceReport(TransactionCase):
             invoice.comment_template2_id,
             self.sale_order.comment_template2_id,
         )
+
+    def test_onchange_partner_id(self):
+        self.partner_id.comment_template_id = self.after_comment.id
+        vals = {
+            'partner_id': self.partner_id.id,
+        }
+        new_sale = self.env['sale.order'].new(vals)
+        new_sale.onchange_partner_id_sale_comment()
+        sale_dict = new_sale._convert_to_write(new_sale._cache)
+        new_sale = self.env['sale.order'].create(sale_dict)
+        self.assertEqual(new_sale.comment_template2_id, self.after_comment)
+        self.partner_id.comment_template_id = self.before_comment.id
+        new_sale = self.env['sale.order'].new(vals)
+        new_sale.onchange_partner_id_sale_comment()
+        sale_dict = new_sale._convert_to_write(new_sale._cache)
+        new_sale = self.env['sale.order'].create(sale_dict)
+        self.assertEqual(new_sale.comment_template1_id, self.before_comment)


### PR DESCRIPTION
Related: https://github.com/OCA/sale-reporting/pull/46

Add missing feature from older version: now you can assign a comment template to partner.

* Update spanish translation

cc @Tecnativa