### PR TITLE
[FIX] sale_report_delivered_subtotal: divide by zero error

### DIFF
--- a/sale_report_delivered_subtotal/__manifest__.py
+++ b/sale_report_delivered_subtotal/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Sale Report Delivered subtotal",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     'author': 'Tecnativa,'
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/sale-reporting',

--- a/sale_report_delivered_subtotal/reports/sale_report.py
+++ b/sale_report_delivered_subtotal/reports/sale_report.py
@@ -15,7 +15,9 @@ class SaleReport(models.Model):
     def _select(self):
         select_str = super(SaleReport, self)._select()
         select_str += """,
-            sum((l.price_subtotal / l.product_uom_qty) * l.qty_delivered)
+            sum((l.price_subtotal /
+                 coalesce(nullif(l.product_uom_qty, 0), 1)
+                ) * l.qty_delivered)
             as price_subtotal_delivered
         """
         return select_str


### PR DESCRIPTION
- If a sale order line has a product_uom_qty of 0 it will cause a
division by zero error.

cc @Tecnativa