### PR TITLE
[10.0][FIX] avoid reports with empty rows

### DIFF
--- a/sale_comment_template/views/report_saleorder.xml
+++ b/sale_comment_template/views/report_saleorder.xml
@@ -17,17 +17,17 @@
         </p>
       </xpath>
       <xpath expr="//t[@t-foreach='page']/t[@t-as='l']" position="inside">
-        <t t-if="l.formatted_note">
-            <tr style="padding:0;">
-                <td colspan="7" style="padding:0;">
-                    <table style="width:100%;border:0;padding:0;">
-                        <caption class="formatted_note">
-                            <span t-field="l.formatted_note"/>
-                        </caption>
-                    </table>
-                </td>
-            </tr>
-        </t>
+            <t t-if="l.formatted_note and l.formatted_note != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'">
+                <tr style="padding:0;">
+                    <td colspan="7" style="padding:0;">
+                        <table style="width:100%;border:0;padding:0;">
+                            <caption class="formatted_note">
+                                <span t-field="l.formatted_note"/>
+                            </caption>
+                        </table>
+                    </td>
+                </tr>
+            </t>
       </xpath>
       <xpath expr="//p[@t-field='doc.note']" position="after">
         <p t-if="doc.note2">


### PR DESCRIPTION
This is a fix to avoid having empty rows on the QWeb sale order
report that relate to the formatted_note field. If the field has no
content, it shouldn't be displayed. Also note that the default
formatted_note content is <p><br></p> and so we also need to prevent
printing when the field has that value.