### PR TITLE
[13.0][IMP] sale_layount_category_hide_detail hidding amounts

### DIFF
--- a/sale_layout_category_hide_detail/models/account_move.py
+++ b/sale_layout_category_hide_detail/models/account_move.py
@@ -9,3 +9,4 @@ class AccountMoveLine(models.Model):
 
     show_details = fields.Boolean(string="Show details", default=True)
     show_subtotal = fields.Boolean(string="Show subtotal", default=True)
+    show_line_amount = fields.Boolean(string="Show line amount", default=True)

--- a/sale_layout_category_hide_detail/models/sale_order.py
+++ b/sale_layout_category_hide_detail/models/sale_order.py
@@ -9,8 +9,13 @@ class SaleOrderLine(models.Model):
 
     show_details = fields.Boolean(string="Show details", default=True)
     show_subtotal = fields.Boolean(string="Show subtotal", default=True)
+    show_line_amount = fields.Boolean(string="Show line amount", default=True)
 
     def _prepare_invoice_line(self):
         res = super()._prepare_invoice_line()
-        res.update(show_details=self.show_details, show_subtotal=self.show_subtotal)
+        res.update(
+            show_details=self.show_details,
+            show_subtotal=self.show_subtotal,
+            show_line_amount=self.show_line_amount,
+        )
         return res

--- a/sale_layout_category_hide_detail/views/account_move_view.xml
+++ b/sale_layout_category_hide_detail/views/account_move_view.xml
@@ -41,6 +41,22 @@
                 }"
                     attrs="{'invisible': ['|', ('display_type', '!=', 'line_section'), ('show_details', '!=', True)]}"
                 />
+        <field
+                    name="show_line_amount"
+                    widget="boolean_fa_icon"
+                    options="{
+                    'show_in_line_section': true,
+                    'fa_icons': {
+                        'icon_true': 'fa-usd',
+                        'icon_false': 'fa-toggle-off',
+                    },
+                    'terminology': {
+                        'hover_true': 'Switch to: line amount hidden',
+                        'hover_false': 'Switch to: line amount shown',
+                    },
+               }"
+                    attrs="{'invisible': ['|', ('display_type', '!=', 'line_section'), ('show_details', '!=', True)]}"
+                />
       </xpath>
 
       <xpath
@@ -93,6 +109,10 @@
                     />
           <field
                         name="show_subtotal"
+                        attrs="{'invisible': ['|', ('display_type', '!=', 'line_section'), ('show_details', '!=', True)]}"
+                    />
+          <field
+                        name="show_line_amount"
                         attrs="{'invisible': ['|', ('display_type', '!=', 'line_section'), ('show_details', '!=', True)]}"
                     />
         </group>

--- a/sale_layout_category_hide_detail/views/sale_order_report_templates.xml
+++ b/sale_layout_category_hide_detail/views/sale_order_report_templates.xml
@@ -73,5 +73,35 @@
         </tr>
       </t>
     </xpath>
+
+    <xpath expr="//td[@name='td_priceunit']/span" position="attributes">
+      <attribute
+                name="t-if"
+                add="not current_section or current_section.show_line_amount"
+                separator=" and "
+            />
+    </xpath>
+    <xpath expr="//td[@name='td_taxes']/span" position="attributes">
+      <attribute
+                name="t-if"
+                add="not current_section or current_section.show_line_amount"
+                separator=" and "
+            />
+    </xpath>
+    <xpath expr="//td[@name='td_subtotal']/span" position="attributes">
+      <attribute
+                name="t-if"
+                add="not current_section or current_section.show_line_amount"
+                separator=" and "
+            />
+    </xpath>
+    <xpath expr="//td[@t-if='display_discount']/span" position="attributes">
+      <attribute
+                name="t-if"
+                add="not current_section or current_section.show_line_amount"
+                separator=" and "
+            />
+    </xpath>
+
   </template>
 </odoo>

--- a/sale_layout_category_hide_detail/views/sale_views.xml
+++ b/sale_layout_category_hide_detail/views/sale_views.xml
@@ -20,6 +20,10 @@
                         name="show_subtotal"
                         attrs="{'invisible': ['|', ('display_type', '!=', 'line_section'), ('show_details', '!=', True)]}"
                     />
+                    <field
+                        name="show_line_amount"
+                        attrs="{'invisible': ['|', ('display_type', '!=', 'line_section'), ('show_details', '!=', True)]}"
+                    />
                 </group>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree" position="inside">
@@ -51,6 +55,22 @@
                             'terminology': {
                                 'hover_true': 'Switch to: subtotal hidden',
                                 'hover_false': 'Switch to: subtotal shown',
+                            },
+                       }"
+                    attrs="{'invisible': ['|', ('display_type', '!=', 'line_section'), ('show_details', '!=', True)]}"
+                />
+                <field
+                    name="show_line_amount"
+                    widget="boolean_fa_icon"
+                    options="{
+                            'show_in_line_section': true,
+                            'fa_icons': {
+                                'icon_true': 'fa-usd',
+                                'icon_false': 'fa-toggle-off',
+                            },
+                            'terminology': {
+                                'hover_true': 'Switch to: line amount hidden',
+                                'hover_false': 'Switch to: line amount shown',
                             },
                        }"
                     attrs="{'invisible': ['|', ('display_type', '!=', 'line_section'), ('show_details', '!=', True)]}"


### PR DESCRIPTION
This includes #76 while it is not merged.
And also adds a third option on a section. The option when selected hides all amounts in the detail of the section.