### PR TITLE
[FIX][12.0] group menu sale backorder missing

### DIFF
--- a/sale_backorder/wizard/so_backorder_wizard_view.xml
+++ b/sale_backorder/wizard/so_backorder_wizard_view.xml
@@ -32,5 +32,6 @@
     <menuitem id="menu_so_backorder_report"
               action="action_so_backorder_wizard"
               parent="sale.sale_order_menu"
+              groups="sales_team.group_sale_salesman"
               sequence="12"/>
 </odoo>


### PR DESCRIPTION
Description: without this group permission, menu is visible to everyone.
How to replicate: create an user without sale permission.
Before this PR: user see anyway Sale app menu, but only with print menu of SO Backorder.
After this PR: user do not see Sale app menu.