### PR TITLE
[12.0][FIX] change partner do not update comment translation

### DIFF
--- a/sale_comment_template/models/sale_order.py
+++ b/sale_comment_template/models/sale_order.py
@@ -42,6 +42,8 @@ class SaleOrder(models.Model):
     @api.onchange('partner_id')
     def onchange_partner_id_sale_comment(self):
         if self.partner_id:
+            self._set_note1()
+            self._set_note2()
             comment_template = self.partner_id.property_comment_template_id
             if comment_template.position == 'before_lines':
                 self.comment_template1_id = comment_template


### PR DESCRIPTION
Use case: set a comment template in SO directly or as a default. Do not set a default comment template in partner. If partner is changed, the comment remains the same, even if there are translations.

Before this PR: the comment is not updated on partner's language.

After this PR: the comment is updated on partner's language.