### PR TITLE
[13.0][ADD] sale_order_line_position

### DIFF
--- a/sale_order_line_position/__init__.py
+++ b/sale_order_line_position/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_order_line_position/__manifest__.py
+++ b/sale_order_line_position/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Sale 0rder Line Position",
+    "summary": "Adds position number on sale order line.",
+    "version": "13.0.1.0.0",
+    "category": "Sales",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "https://github.com/OCA/sale-reporting",
+    "depends": ["sale"],
+    "data": ["views/sale_order.xml", "report/sale_order_report.xml"],
+    "installable": True,
+}

--- a/sale_order_line_position/models/__init__.py
+++ b/sale_order_line_position/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order
+from . import sale_order_line

--- a/sale_order_line_position/models/sale_order.py
+++ b/sale_order_line_position/models/sale_order.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    locked_positions = fields.Boolean(compute="_compute_locked_positions")
+
+    @api.depends("state")
+    def _compute_locked_positions(self):
+        for record in self:
+            record.locked_positions = record.state != "draft"
+
+    def action_quotation_send(self):
+        self.recompute_positions()
+        return super().action_quotation_send()
+
+    def recompute_positions(self):
+        self.ensure_one()
+        if self.locked_positions:
+            return
+        lines = self.order_line.filtered(lambda l: not l.display_type)
+        lines.sorted(key=lambda x: x.sequence)
+        for position, line in enumerate(lines, start=1):
+            line.position = position

--- a/sale_order_line_position/models/sale_order_line.py
+++ b/sale_order_line_position/models/sale_order_line.py
@@ -1,0 +1,68 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    position = fields.Integer(readonly=True, index=True, default=False)
+    position_formatted = fields.Char(compute="_compute_position_formatted")
+
+    @api.depends("position")
+    def _compute_position_formatted(self):
+        for record in self:
+            record.position_formatted = record._format_position(record.position)
+
+    @api.onchange("sequence")
+    def _onchange_sequence(self):
+        if self.order_id.locked_positions:
+            return
+        lines = self.order_id.order_line.filtered(
+            lambda x: not x.display_type and x.sequence < self.sequence
+        )
+        self.position = len(lines) + 1
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        vals_list = self._add_next_position_on_new_line(vals_list)
+        return super().create(vals_list)
+
+    def unlink(self):
+        sales = self.mapped("order_id")
+        res = super().unlink()
+        for sale in sales:
+            sale.recompute_positions()
+        return res
+
+    def _add_next_position_on_new_line(self, vals_list):
+        sale_ids = [
+            line["order_id"]
+            for line in vals_list
+            if not line.get("display_type") and line.get("order_id")
+        ]
+        if sale_ids:
+            ids = tuple(set(sale_ids))
+            self.flush()
+            query = """
+            SELECT order_id, max(position) FROM sale_order_line
+            WHERE order_id in %s GROUP BY order_id;
+            """
+            self.env.cr.execute(query, (ids,))
+            default_pos = {key: 1 for key in ids}
+            existing_pos = {
+                order_id: pos + 1 for order_id, pos in self.env.cr.fetchall()
+            }
+            sale_pos = {**default_pos, **existing_pos}
+            for line in vals_list:
+                if not line.get("display_type"):
+                    line["position"] = sale_pos[line["order_id"]]
+                    sale_pos[line["order_id"]] += 1
+        return vals_list
+
+    @api.model
+    def _format_position(self, position):
+        if not position:
+            return ""
+        return str(position).zfill(3)

--- a/sale_order_line_position/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_position/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/sale_order_line_position/readme/DESCRIPTION.rst
+++ b/sale_order_line_position/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+This module adds an auto computed position on sale order line.
+This position number is added on the report.
+
+The position can be used to keep track of each line during
+the delivery and invoicing of the order with the customer.
+This is why there are related modules on `account-invoice-reporting`
+and `stock-logisics-reporting`.
+
+The position is not changed on the line after the order has been send.

--- a/sale_order_line_position/readme/ROADMAP.rst
+++ b/sale_order_line_position/readme/ROADMAP.rst
@@ -1,0 +1,14 @@
+The way the positions are computed on the create of `sale.order.line`
+record could lead to a performance issue. There is a few improvements
+that have been suggested:
+
+Remove it and handle the computation on the write and/or create
+method of the `sale.order`.
+
+Have a context key to enable/disable the recomputation.
+
+Do not set any value in the position fields before the sale order lines
+are locked (in the current implementation, before sending).
+And add a recompute button in the UI.
+
+Set the position values with an SQL query using a `TRIGGER`.

--- a/sale_order_line_position/report/sale_order_report.xml
+++ b/sale_order_line_position/report/sale_order_report.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="report_saleorder_document"
+        inherit_id="sale.report_saleorder_document"
+    >
+        <xpath expr="//table/thead/tr/th[@name='th_description']" position="before">
+            <th class="text-left">Pos</th>
+        </xpath>
+        <xpath
+            expr="//table/tbody[hasclass('sale_tbody')]//td[@name='td_name']"
+            position="before"
+        >
+            <td>
+                <span t-field="line.position" />
+            </td>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_order_line_position/tests/__init__.py
+++ b/sale_order_line_position/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_line_position

--- a/sale_order_line_position/tests/test_sale_order_line_position.py
+++ b/sale_order_line_position/tests/test_sale_order_line_position.py
@@ -1,0 +1,82 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
+
+
+class TestSaleOrderLinePosition(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner = cls.env.ref("base.res_partner_12")
+        cls.product = cls.env.ref("product.product_product_9")
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "product_uom": cls.product.uom_id.id,
+                            "product_uom_qty": 3.0,
+                        },
+                    ),
+                    (0, 0, {"display_type": "line_section", "name": "Section"}),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "product_uom": cls.product.uom_id.id,
+                            "product_uom_qty": 5.0,
+                        },
+                    ),
+                ],
+            }
+        )
+
+    def test_new_line_position(self):
+        """Check that new line created get a new incremental position number."""
+        line1 = self.order.order_line[0]
+        self.assertEqual(line1.position, 1)
+        self.assertEqual(line1.position_formatted, "001")
+        line2 = self.order.order_line[1]
+        self.assertEqual(line2.position, 0)
+        self.assertEqual(line2.position_formatted, "")
+        line3 = self.env["sale.order.line"].create(
+            [
+                {
+                    "order_id": self.order.id,
+                    "product_id": self.product.id,
+                    "product_uom": self.product.uom_id.id,
+                    "product_uom_qty": 9.0,
+                },
+            ]
+        )
+        self.assertEqual(line3.position, 3)
+        self.assertEqual(line3.position_formatted, "003")
+
+    def test_unlink_line(self):
+        """Check that when line are being removed position are recomputed."""
+        self.order.order_line[0].unlink()
+        self.assertEqual(len(self.order.order_line), 2)
+        self.assertEqual(self.order.order_line[1].position, 1)
+
+    def test_locked_positions(self):
+        """Check that when order is sent, position are not recomputed."""
+        new_line = self.env["sale.order.line"].create(
+            [
+                {
+                    "order_id": self.order.id,
+                    "product_id": self.product.id,
+                    "product_uom": self.product.uom_id.id,
+                    "product_uom_qty": 15.0,
+                },
+            ]
+        )
+        self.assertEqual(new_line.position, 3)
+        self.order.state = "sent"
+        self.order.order_line[0].unlink()
+        self.assertEqual(new_line.position, 3)

--- a/sale_order_line_position/views/sale_order.xml
+++ b/sale_order_line_position/views/sale_order.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.sale.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='order_line']//form//field[@name='sequence']"
+                position="after"
+            >
+              <field name="position" force_save="1" />
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']//tree//field[@name='sequence']"
+                position="after"
+            >
+              <field name="position" string="Pos" force_save="1" optional="hide" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/sale_order_line_position/odoo/addons/sale_order_line_position
+++ b/setup/sale_order_line_position/odoo/addons/sale_order_line_position
@@ -1,0 +1,1 @@
+../../../../sale_order_line_position

--- a/setup/sale_order_line_position/setup.py
+++ b/setup/sale_order_line_position/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds an auto computed position on sale order line.
This position number is added on the report.

The position can be used to keep track of each line during
the delivery, invoicing of the order with the customer.
This is why there is related modules on `account-invoice-reporting`
and `stock-logisics-reporting`.

The position set on a line is not changed when the order is not in
draft anymore.