### PR TITLE
[13.0][FIX] sale-order-line-position

### DIFF
--- a/sale_order_line_position/models/__init__.py
+++ b/sale_order_line_position/models/__init__.py
@@ -1,2 +1,3 @@
+from . import ir_actions_report
 from . import sale_order
 from . import sale_order_line

--- a/sale_order_line_position/models/ir_actions_report.py
+++ b/sale_order_line_position/models/ir_actions_report.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def render_qweb_pdf(self, res_ids=None, data=None):
+        self.sale_recompute_positions(res_ids)
+        return super().render_qweb_pdf(res_ids, data)
+
+    def sale_recompute_positions(self, res_ids):
+        if self.model == "sale.order":
+            sales = self.env["sale.order"].browse(res_ids)
+            sales.recompute_positions()

--- a/sale_order_line_position/models/sale_order_line.py
+++ b/sale_order_line_position/models/sale_order_line.py
@@ -15,15 +15,6 @@ class SaleOrderLine(models.Model):
         for record in self:
             record.position_formatted = record._format_position(record.position)
 
-    @api.onchange("sequence")
-    def _onchange_sequence(self):
-        if self.order_id.locked_positions:
-            return
-        lines = self.order_id.order_line.filtered(
-            lambda x: not x.display_type and x.sequence < self.sequence
-        )
-        self.position = len(lines) + 1
-
     @api.model_create_multi
     def create(self, vals_list):
         vals_list = self._add_next_position_on_new_line(vals_list)

--- a/sale_order_line_position/readme/DESCRIPTION.rst
+++ b/sale_order_line_position/readme/DESCRIPTION.rst
@@ -1,9 +1,14 @@
 This module adds an auto computed position on sale order line.
-This position number is added on the report.
+This position number is also printed on the report.
 
 The position can be used to keep track of each line during
 the delivery and invoicing of the order with the customer.
 This is why there are related modules on `account-invoice-reporting`
 and `stock-logisics-reporting`.
 
-The position is not changed on the line after the order has been send.
+The positions are recomputed when the sale order is printed, sent and set to confirm.
+
+The positions are not changed on the line after the order has been confirmed, but if
+new line are added they will receive a position number.
+
+An action is also availabled to manually recompute the positions.

--- a/sale_order_line_position/views/sale_order.xml
+++ b/sale_order_line_position/views/sale_order.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
+
     <record id="view_order_form_inherit" model="ir.ui.view">
         <field name="name">sale.order.form.sale.inherit</field>
         <field name="model">sale.order</field>
@@ -20,4 +21,15 @@
             </xpath>
         </field>
     </record>
+
+    <record model="ir.actions.server" id="action_compute_sale_position">
+      <field name="name">Recompute positions</field>
+      <field name="model_id" ref="sale.model_sale_order" />
+      <field name="binding_model_id" ref="sale.model_sale_order" />
+      <field name="state">code</field>
+      <field name="code">
+        records.recompute_positions()
+      </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
The previous implementation with the onchange was broken and hardly
feasible (onchange are called on each line and the sequence set on them
changes on each call) and not possible to cover with unit
tests (reproduce the drag and drop).

The other solution could have been to replace the onchange with a
recompute of the position on every `write` of a sale.order but that
also leads to a complex solution.

As the positions are needed to discuss with the customer, the recompute of the
position on print, send and confirm is a good enough, simple solution.

- [ ] When reviewed it needs a forward port to 14.0