### PR TITLE
[13.0][IMP] product_sold_by_delivery_week: Performance pre-searching data

### DIFF
--- a/product_sold_by_delivery_week/README.rst
+++ b/product_sold_by_delivery_week/README.rst
@@ -46,6 +46,11 @@ We can configure some variables with config parameter keys:
   - For the not sold: `product_sold_by_delivery_week.not_sold_char`
 - For weeks length: `product_sold_by_delivery_week.weeks_to_consider`
 
+Assign the security group 'Weekly selling info in order lines' and/or
+'Weekly selling info in product list' to users that should see weekly
+selling info in order lines or product list. (Is is not necessary if
+you want view the info in other views as product recommendation)
+
 Usage
 =====
 
@@ -90,6 +95,7 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * David Vidal
+  * Carlos Dauden
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_sold_by_delivery_week/__manifest__.py
+++ b/product_sold_by_delivery_week/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Tecnativa - David Vidal
+# Copyright 2021 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Product weekly sales hint",
@@ -11,6 +12,11 @@
     "maintainers": ["chienandalu"],
     "license": "AGPL-3",
     "depends": ["sale_stock"],
-    "data": ["data/ir_cron.xml", "views/product_views.xml", "views/sale_views.xml"],
+    "data": [
+        "data/ir_cron.xml",
+        "security/product_sold_by_delivery_week_security.xml",
+        "views/product_views.xml",
+        "views/sale_views.xml",
+    ],
     "post_init_hook": "post_init_hook",
 }

--- a/product_sold_by_delivery_week/i18n/es.po
+++ b/product_sold_by_delivery_week/i18n/es.po
@@ -6,15 +6,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 12:16+0000\n"
-"PO-Revision-Date: 2021-10-19 14:17+0200\n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2021-11-17 18:34+0000\n"
+"PO-Revision-Date: 2021-11-17 19:36+0100\n"
+"Last-Translator: Carlos Dauden <carlos.dauden@tecnativa.com>\n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"Language: es\n"
 "X-Generator: Poedit 2.3\n"
 
 #. module: product_sold_by_delivery_week
@@ -56,3 +56,13 @@ msgstr "Venta semanal"
 #: model:ir.model.fields,field_description:product_sold_by_delivery_week.field_product_template__weekly_sold_delivered
 msgid "Weekly Sold Delivered"
 msgstr "Vendidos y entregados semanalmente"
+
+#. module: product_sold_by_delivery_week
+#: model:res.groups,name:product_sold_by_delivery_week.group_weekly_selling_order_line
+msgid "Weekly selling info in order lines"
+msgstr "Información de venta semanal en líneas de pedido"
+
+#. module: product_sold_by_delivery_week
+#: model:res.groups,name:product_sold_by_delivery_week.group_weekly_selling_product_list
+msgid "Weekly selling info in product list"
+msgstr "Información de venta semanal en lista de productos"

--- a/product_sold_by_delivery_week/i18n/product_sold_by_delivery_week.pot
+++ b/product_sold_by_delivery_week/i18n/product_sold_by_delivery_week.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-17 18:34+0000\n"
+"PO-Revision-Date: 2021-11-17 18:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -51,4 +53,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:product_sold_by_delivery_week.field_product_product__weekly_sold_delivered
 #: model:ir.model.fields,field_description:product_sold_by_delivery_week.field_product_template__weekly_sold_delivered
 msgid "Weekly Sold Delivered"
+msgstr ""
+
+#. module: product_sold_by_delivery_week
+#: model:res.groups,name:product_sold_by_delivery_week.group_weekly_selling_order_line
+msgid "Weekly selling info in order lines"
+msgstr ""
+
+#. module: product_sold_by_delivery_week
+#: model:res.groups,name:product_sold_by_delivery_week.group_weekly_selling_product_list
+msgid "Weekly selling info in product list"
 msgstr ""

--- a/product_sold_by_delivery_week/readme/CONFIGURE.rst
+++ b/product_sold_by_delivery_week/readme/CONFIGURE.rst
@@ -5,3 +5,8 @@ We can configure some variables with config parameter keys:
   - For the sold char: `product_sold_by_delivery_week.sold_char`
   - For the not sold: `product_sold_by_delivery_week.not_sold_char`
 - For weeks length: `product_sold_by_delivery_week.weeks_to_consider`
+
+Assign the security group 'Weekly selling info in order lines' and/or
+'Weekly selling info in product list' to users that should see weekly
+selling info in order lines or product list. (Is is not necessary if
+you want view the info in other views as product recommendation)

--- a/product_sold_by_delivery_week/readme/CONTRIBUTORS.rst
+++ b/product_sold_by_delivery_week/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * David Vidal
+  * Carlos Dauden

--- a/product_sold_by_delivery_week/security/product_sold_by_delivery_week_security.xml
+++ b/product_sold_by_delivery_week/security/product_sold_by_delivery_week_security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="group_weekly_selling_order_line" model="res.groups">
+        <field name="name">Weekly selling info in order lines</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
+    <record id="group_weekly_selling_product_list" model="res.groups">
+        <field name="name">Weekly selling info in product list</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
+</odoo>

--- a/product_sold_by_delivery_week/static/description/index.html
+++ b/product_sold_by_delivery_week/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Product weekly sales hint</title>
 <style type="text/css">
 
@@ -397,6 +397,10 @@ whether or not that product was sold and delivered in the past weeks.</p>
 </li>
 <li>For weeks length: <cite>product_sold_by_delivery_week.weeks_to_consider</cite></li>
 </ul>
+<p>Assign the security group ‘Weekly selling info in order lines’ and/or
+‘Weekly selling info in product list’ to users that should see weekly
+selling info in order lines or product list. (Is is not necessary if
+you want view the info in other views as product recommendation)</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>
@@ -437,6 +441,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>David Vidal</li>
+<li>Carlos Dauden</li>
 </ul>
 </li>
 </ul>

--- a/product_sold_by_delivery_week/views/product_views.xml
+++ b/product_sold_by_delivery_week/views/product_views.xml
@@ -5,7 +5,10 @@
     <record id="product_template_tree_view" model="ir.ui.view">
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_tree_view" />
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('product_sold_by_delivery_week.group_weekly_selling_product_list'))]"
+        />
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <!-- The BS badge class provides some styles that will avoid that
@@ -22,7 +25,10 @@
     <record id="product_product_tree_view" model="ir.ui.view">
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_product_tree_view" />
-        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('product_sold_by_delivery_week.group_weekly_selling_product_list'))]"
+        />
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <!-- The BS badge class provides some styles that will avoid that

--- a/product_sold_by_delivery_week/views/sale_views.xml
+++ b/product_sold_by_delivery_week/views/sale_views.xml
@@ -5,6 +5,10 @@
     <record id="view_order_form" model="ir.ui.view">
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
+        <field
+            name="groups_id"
+            eval="[(4, ref('product_sold_by_delivery_week.group_weekly_selling_order_line'))]"
+        />
         <field name="arch" type="xml">
             <xpath expr="//tree//field[@name='name']" position="after">
                 <!-- The BS badge class provides some styles that will avoid that


### PR DESCRIPTION
instead use dot notation.
Add security groups to avoid unnecessary compute.  

@Tecnativa TT32983