### PR TITLE
[FIX][12.0] sale_comment_template: html field breaks boxed report

### DIFF
--- a/sale_comment_template/views/report_saleorder.xml
+++ b/sale_comment_template/views/report_saleorder.xml
@@ -18,7 +18,7 @@
       </xpath>
 
       <xpath expr="//t[@t-foreach='doc.order_line']" position="inside">
-        <t t-if="line.formatted_note">
+        <t t-if="line.formatted_note != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'">
             <tr style="padding:0;">
                 <td colspan="7" style="padding:0;">
                     <table style="width:100%;border:0;padding:0;">


### PR DESCRIPTION
Because html field always store `<p><br></p>` tags. So always is printed this table: https://github.com/OCA/sale-reporting/blob/12.0/sale_comment_template/views/report_saleorder.xml#L24

Before this patch:

![before](https://user-images.githubusercontent.com/4386443/153431990-26534e08-6872-4fb4-a96f-5fb4fdf9d357.png)

After this patch:

![after](https://user-images.githubusercontent.com/4386443/153432043-06bca10c-ba0d-4c68-808c-371afe8ac61a.png)
