### PR TITLE
[14.0][FIX] sale_layout_category_hide_detail: Set the correct URL of the icons in readme.

### DIFF
--- a/sale_layout_category_hide_detail/README.rst
+++ b/sale_layout_category_hide_detail/README.rst
@@ -68,19 +68,19 @@ following:
 
 The behavior described before is the same for Quotations and Invoices.
 
-.. |eye-icon| image:: https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/sale_layout_category_hide_detail/static/description/readme-icons/eye.png
+.. |eye-icon| image:: https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/static/description/readme-icons/eye.png
    :alt: plus-circle icon
    :width: 12 px
 
-.. |eye-slash-icon| image:: https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/sale_layout_category_hide_detail/static/description/readme-icons/eye-slash.png
+.. |eye-slash-icon| image:: https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/static/description/readme-icons/eye-slash.png
    :alt: minus-circle icon
    :width: 12 px
 
-.. |plus-circle-icon| image:: https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/sale_layout_category_hide_detail/static/description/readme-icons/plus-circle.png
+.. |plus-circle-icon| image:: https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/static/description/readme-icons/plus-circle.png
    :alt: plus-circle icon
    :width: 12 px
 
-.. |minus-circle-icon| image:: https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/sale_layout_category_hide_detail/static/description/readme-icons/minus-circle.png
+.. |minus-circle-icon| image:: https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/static/description/readme-icons/minus-circle.png
    :alt: minus-circle icon
    :width: 12 px
 

--- a/sale_layout_category_hide_detail/readme/USAGE.rst
+++ b/sale_layout_category_hide_detail/readme/USAGE.rst
@@ -28,18 +28,18 @@ following:
 
 The behavior described before is the same for Quotations and Invoices.
 
-.. |eye-icon| image:: sale_layout_category_hide_detail/static/description/readme-icons/eye.png
+.. |eye-icon| image:: ../static/description/readme-icons/eye.png
    :alt: plus-circle icon
    :width: 12 px
 
-.. |eye-slash-icon| image:: sale_layout_category_hide_detail/static/description/readme-icons/eye-slash.png
+.. |eye-slash-icon| image:: ../static/description/readme-icons/eye-slash.png
    :alt: minus-circle icon
    :width: 12 px
 
-.. |plus-circle-icon| image:: sale_layout_category_hide_detail/static/description/readme-icons/plus-circle.png
+.. |plus-circle-icon| image:: ../static/description/readme-icons/plus-circle.png
    :alt: plus-circle icon
    :width: 12 px
 
-.. |minus-circle-icon| image:: sale_layout_category_hide_detail/static/description/readme-icons/minus-circle.png
+.. |minus-circle-icon| image:: ../static/description/readme-icons/minus-circle.png
    :alt: minus-circle icon
    :width: 12 px

--- a/sale_layout_category_hide_detail/static/description/index.html
+++ b/sale_layout_category_hide_detail/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Sale layout category hide detail</title>
 <style type="text/css">
 
@@ -394,12 +394,12 @@ lines or their subtotals in the PDF report and in the website.</p>
 <li>In <em>Order lines</em> tab add a section line.</li>
 <li>Add some product lines.</li>
 <li>Add another section line, but this time, click on the <em>plus-circle</em>
-icon <img alt="plus-circle icon" src="https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/sale_layout_category_hide_detail/static/description/readme-icons/plus-circle.png" style="width: 12px;" /> on your right. That icon will be replaced by
-<em>minus-circle</em> icon <img alt="minus-circle icon" src="https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/sale_layout_category_hide_detail/static/description/readme-icons/minus-circle.png" style="width: 12px;" />. That mean <em>Show subtotal</em> field is
+icon <img alt="plus-circle icon" src="https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/static/description/readme-icons/plus-circle.png" style="width: 12px;" /> on your right. That icon will be replaced by
+<em>minus-circle</em> icon <img alt="minus-circle icon" src="https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/static/description/readme-icons/minus-circle.png" style="width: 12px;" />. That mean <em>Show subtotal</em> field is
 set to False.</li>
 <li>Add some product lines.</li>
-<li>Add another section line and click on the <em>eye</em> icon <img alt="plus-circle icon" src="https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/sale_layout_category_hide_detail/static/description/readme-icons/eye.png" style="width: 12px;" /> on your
-right. That icon will be replaced by <em>eye-slash</em> icon <img alt="minus-circle icon" src="https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/sale_layout_category_hide_detail/static/description/readme-icons/eye-slash.png" style="width: 12px;" />.
+<li>Add another section line and click on the <em>eye</em> icon <img alt="plus-circle icon" src="https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/static/description/readme-icons/eye.png" style="width: 12px;" /> on your
+right. That icon will be replaced by <em>eye-slash</em> icon <img alt="minus-circle icon" src="https://raw.githubusercontent.com/OCA/sale-reporting/14.0/sale_layout_category_hide_detail/static/description/readme-icons/eye-slash.png" style="width: 12px;" />.
 That mean <em>Show details</em> field is set to False.</li>
 <li>Add some product lines.</li>
 <li>Print a <em>Quotation / Order</em> report for this quotation.</li>


### PR DESCRIPTION
Related to: https://github.com/OCA/sale-reporting/pull/170#issuecomment-1235700459

Set the correct URL of the icons in readme.

Please @pedrobaeza can you review it?

@Tecnativa