### PR TITLE
[FIX][12.0] sale_comment_template: remove comparison

### DIFF
--- a/sale_comment_template/views/report_saleorder.xml
+++ b/sale_comment_template/views/report_saleorder.xml
@@ -18,7 +18,7 @@
       </xpath>
 
       <xpath expr="//t[@t-foreach='doc.order_line']" position="inside">
-        <t t-if="line.formatted_note != '&lt;p&gt;&lt;br&gt;&lt;/p&gt;'">
+        <t t-if="line.formatted_note">
             <tr style="padding:0;">
                 <td colspan="7" style="padding:0;">
                     <table style="width:100%;border:0;padding:0;">


### PR DESCRIPTION
Reverts https://github.com/OCA/sale-reporting/pull/133

Something has changed and not is necessary now.