### PR TITLE
[14.0][FIX] sale_layout_category_hide_detail: Add fields to line_ids tree to be sure boolean_fa_icon work fine in all use cases

### DIFF
--- a/sale_layout_category_hide_detail/views/account_move_view.xml
+++ b/sale_layout_category_hide_detail/views/account_move_view.xml
@@ -114,7 +114,12 @@
               </div>
           </t>
       </xpath>
-
+      <xpath expr="//field[@name='line_ids']/tree" position="inside">
+        <field name="show_details" invisible="1" />
+        <field name="show_section_subtotal" invisible="1" />
+        <field name="show_subtotal" invisible="1" />
+        <field name="show_line_amount" invisible="1" />
+      </xpath>
       <xpath
                 expr="//field[@name='invoice_line_ids']/form/sheet/field[@name='name']"
                 position="after"


### PR DESCRIPTION
Add fields to `line_ids` tree to be sure _boolean_fa_icon_ work fine in all use cases

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38579