### PR TITLE
[13.0][FIX] sale_order_product_recommendation_product_sold_by_delivery_week…

### DIFF
--- a/sale_order_product_recommendation_product_sold_by_delivery_week/wizard/sale_order_recommendation.py
+++ b/sale_order_product_recommendation_product_sold_by_delivery_week/wizard/sale_order_recommendation.py
@@ -16,7 +16,11 @@ class SaleOrderRecommendationLine(models.TransientModel):
         _format_weekly_string = self.env["product.product"]._format_weekly_string
         self.weekly_sold_delivered_shown = False
         products = self.mapped("product_id").filtered(lambda x: x.type != "service")
-        common_partner = self.wizard_id.order_id.partner_id.commercial_partner_id
+        recommend_wiz = self.wizard_id
+        if recommend_wiz.use_delivery_address:
+            common_partner = recommend_wiz.order_id.partner_shipping_id
+        else:
+            common_partner = recommend_wiz.order_id.partner_id.commercial_partner_id
         products_weekly = products.with_context(
             weekly_partner_id=common_partner.id,
         )._weekly_sold_delivered()


### PR DESCRIPTION
…: Fix use of use_delivery_address and weekly_partner_ids

Take into account use_delivery_address field:
https://github.com/OCA/sale-workflow/blob/0289b0c85ab223700ec795741aac9d3c6c1ba32b/sale_order_product_recommendation/wizards/sale_order_recommendation.py#L58-L65

@Tecnativa TT40433