### PR TITLE
[16.0] sale_order_line_position + sale_layout_category_hide_detail fix

### DIFF
--- a/sale_layout_category_hide_detail/views/invoice_report_templates.xml
+++ b/sale_layout_category_hide_detail/views/invoice_report_templates.xml
@@ -85,7 +85,7 @@
             />
       </xpath>
       <xpath
-            expr="//t[@t-foreach='lines']//span[contains(@t-esc, 'line.tax_ids')]"
+            expr="//t[@t-foreach='lines']//span[@id='line_tax_ids']"
             position="attributes"
         >
         <attribute

--- a/sale_order_line_position/models/sale_order_line.py
+++ b/sale_order_line_position/models/sale_order_line.py
@@ -35,7 +35,7 @@ class SaleOrderLine(models.Model):
         ]
         if sale_ids:
             ids = tuple(set(sale_ids))
-            self.flush()
+            self.flush_model()
             query = """
             SELECT order_id, max(position) FROM sale_order_line
             WHERE order_id in %s GROUP BY order_id;


### PR DESCRIPTION
Fix `sale_order_line.py:38: DeprecationWarning: Deprecated method flush(), use flush_model(), flush_recordset() or env.flush_all() instead`

Collateral fix for `sale_layout_category_hide_detail` for odoo code change.