### PR TITLE
[15.0][FIX] sale_comment_template: fix action to allow to see templates in sales

### DIFF
--- a/sale_comment_template/views/base_comment_template_view.xml
+++ b/sale_comment_template/views/base_comment_template_view.xml
@@ -5,11 +5,8 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.comment.template</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('model_ids.model', '=', 'sale.order')]</field>
-        <field
-            name="context"
-            eval="{'default_model_ids': [(4, ref('sale.model_sale_order'))]}"
-        />
+        <field name="domain">[('model_ids', '=', 'sale.order')]</field>
+        <field name="context">{'default_models': 'sale.order'}</field>
         <field
             name="view_id"
             ref="base_comment_template.view_base_comment_template_tree"


### PR DESCRIPTION
This commit addresses the following issues:
Resolved an issue where users were unable to view templates in the comment list due to an incorrect domain configuration in the action.
Updated the context to set the sale order as the default option.