### PR TITLE
[15.0][FIX] sale_layout_category_hide_detail: Full width to note lines

### DIFF
--- a/sale_layout_category_hide_detail/static/src/js/sale_layout_category_hide_detail.js
+++ b/sale_layout_category_hide_detail/static/src/js/sale_layout_category_hide_detail.js
@@ -33,9 +33,7 @@ odoo.define(
             },
             _renderBodyCell: function (record, node) {
                 var $cell = this._super.apply(this, arguments);
-                var isSection = record.data.display_type === "line_section";
-                var isNote = record.data.display_type === "line_note";
-                if (isSection || isNote) {
+                if (record.data.display_type === "line_section") {
                     if (this._allowRemoveClassHidden(node.attrs.name)) {
                         return $cell.removeClass("o_hidden");
                     } else if (node.attrs.name === "name") {


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/sale-reporting/pull/268

Note type lines do not need to add any logic, they need to maintain full width.

**Before**
![antes](https://github.com/OCA/sale-reporting/assets/4117568/2b4eec2a-0906-49e9-ab41-e681f20b32c8)

**After**
![despues](https://github.com/OCA/sale-reporting/assets/4117568/bd6b8c9c-0ef6-4472-b339-167f41c04e3b)

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT49131