### PR TITLE
[FIX] [16.0] sale_report_delivered: Consider 0.0 Value valuation layers

### DIFF
--- a/sale_report_delivered/reports/sale_report.py
+++ b/sale_report_delivered/reports/sale_report.py
@@ -145,7 +145,7 @@ class SaleReportDeliverd(models.Model):
             s.id as order_id,
             sp.id as picking_id,
             sol.purchase_price AS unsigned_purchase_price,
-            ROUND(svl.value, cur.decimal_places) AS amount_cost
+            ROUND(COALESCE(svl.value, 0.0), cur.decimal_places) AS amount_cost
         """
         return sub_select_str
 


### PR DESCRIPTION
Take in consideration valuation layers when quantity delivered exceedes demanded quantity.

# Why I've changed the subquery line:
Use COALESCE in subselect query to avoid COALESCE in select query


# Before
https://www.loom.com/share/4c1b1ef838884b3c8dd3c5a6eed9368b?sid=a7524baa-9feb-46d9-b7a0-4d8f687177a8



MT-6136 @moduon @rafaelbn @Gelojr  @fcvalgar  please review if you want :)