### PR TITLE
[FIX] [16.0] sale_packaging_report: Do not cut packaging text on reports

### DIFF
--- a/sale_packaging_report/views/report_sale_order.xml
+++ b/sale_packaging_report/views/report_sale_order.xml
@@ -10,6 +10,7 @@
             <div
                 t-if="line.product_packaging_id"
                 class="text-secondary"
+                style="white-space: nowrap;"
                 groups="product.group_stock_packaging"
             >
                 <span t-field="line.product_packaging_id" />:


### PR DESCRIPTION
Do not cut packaging text on reports (Quotation and Sale)

# Before
![image](https://github.com/OCA/sale-reporting/assets/1162050/255e3aa3-f479-479c-9d61-1443e0c04674)

# After
![image](https://github.com/OCA/sale-reporting/assets/1162050/1bf72167-c7eb-4853-96d4-21221335a6ca)

MT-6143 @moduon @rafaelbn @Gelojr  @fcvalgar @EmilioPascual please review if you want :)