### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/base_multicompany_reporting_currency/__manifest__.py
+++ b/base_multicompany_reporting_currency/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": "Adds the possibility to specify Multicompany Reporting Currency",
     "version": "15.0.1.0.1",
     "category": "Sales",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["base_setup"],
     "website": "https://github.com/OCA/sale-reporting",

--- a/sale_multicompany_reporting_currency/__manifest__.py
+++ b/sale_multicompany_reporting_currency/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": "Adds Amount in multicompany reporting currency to Sale Order",
     "version": "15.0.1.0.2",
     "category": "Sales",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["sale", "base_multicompany_reporting_currency"],
     "website": "https://github.com/OCA/sale-reporting",

--- a/sale_order_report_customer_lead/__manifest__.py
+++ b/sale_order_report_customer_lead/__manifest__.py
@@ -8,7 +8,7 @@
     "version": "15.0.1.0.1",
     "category": "Sale",
     "website": "https://github.com/OCA/sale-reporting",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ivantodorovich"],
     "license": "AGPL-3",
     "depends": ["sale"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 15.0.