### PR TITLE
[FIX] [16.0] sale_report_delivered: Calculate Dropship moves too

### DIFF
--- a/sale_report_delivered/README.rst
+++ b/sale_report_delivered/README.rst
@@ -31,6 +31,8 @@ Sale Report Delivered
 Adds subtotal price based on the delivered quantities field to the
 *Sales Report*.
 
+This module takes in consideration Outgoing, Returns and Dropship.
+
 **Table of contents**
 
 .. contents::
@@ -67,6 +69,8 @@ Contributors
 
     * Sergio Teruel
     * Carlos Dauden
+
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_report_delivered/readme/CONTRIBUTORS.rst
+++ b/sale_report_delivered/readme/CONTRIBUTORS.rst
@@ -2,3 +2,5 @@
 
     * Sergio Teruel
     * Carlos Dauden
+
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)

--- a/sale_report_delivered/readme/DESCRIPTION.rst
+++ b/sale_report_delivered/readme/DESCRIPTION.rst
@@ -1,2 +1,4 @@
 Adds subtotal price based on the delivered quantities field to the
 *Sales Report*.
+
+This module takes in consideration Outgoing, Returns and Dropship.

--- a/sale_report_delivered/static/description/index.html
+++ b/sale_report_delivered/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -371,6 +372,7 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-reporting/tree/16.0/sale_report_delivered"><img alt="OCA/sale-reporting" src="https://img.shields.io/badge/github-OCA%2Fsale--reporting-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-reporting-16-0/sale-reporting-16-0-sale_report_delivered"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-reporting&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>Adds subtotal price based on the delivered quantities field to the
 <em>Sales Report</em>.</p>
+<p>This module takes in consideration Outgoing, Returns and Dropship.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -416,12 +418,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </blockquote>
 </li>
+<li><p class="first">Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</p>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Calculate costs for Dropship moves too and refunds of Dropship.

PR Series: 
- https://github.com/OCA/sale-reporting/pull/275 (this one)
- https://github.com/OCA/margin-analysis/pull/213

MT-6512 @moduon @rafaelbn @fcvalgar @Gelojr please review if you want :)