### PR TITLE
 [16.0][FIX] sale_layout_category_hide_detail: Full width to note lines

### DIFF
--- a/sale_layout_category_hide_detail/static/src/js/sale_layout_category_hide_detail.esm.js
+++ b/sale_layout_category_hide_detail/static/src/js/sale_layout_category_hide_detail.esm.js
@@ -8,7 +8,16 @@ import {SectionAndNoteListRenderer} from "@account/components/section_and_note_f
 import {patch} from "@web/core/utils/patch";
 
 patch(SectionAndNoteListRenderer.prototype, "new_widgets_buttons_patch", {
+    getColumns(record) {
+        // Set record to use it in getSectionColumns()
+        this.record = record;
+        return this._super.apply(this, arguments);
+    },
     getSectionColumns(columns) {
+        // We do not want to display icons in notes, only in sections
+        if (this.record.data.display_type !== "line_section") {
+            return this._super.apply(this, arguments);
+        }
         var sectionCols = this._super.apply(this, arguments);
         const widgetCols = columns.filter((col) => col.widget === "boolean_fa_icon");
         const sectionWidget = widgetCols.map((col) => {


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/sale-reporting/pull/269

Note type lines do not need to add any logic, they need to maintain full width.

**Before**
![antes](https://github.com/OCA/sale-reporting/assets/4117568/e6b91527-ca70-48f9-83c9-cafc7dde0f22)

**After**
![despues](https://github.com/OCA/sale-reporting/assets/4117568/70f81a23-ffe2-445b-b8f5-e6d48fc39ab6)

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT49131