### PR TITLE
[FIX] sale_layout_category_hide_detail: Improve interoperability, hide discounted price too

### DIFF
--- a/sale_layout_category_hide_detail/views/invoice_report_templates.xml
+++ b/sale_layout_category_hide_detail/views/invoice_report_templates.xml
@@ -66,14 +66,14 @@
     <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
         <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
       </xpath>
       <xpath expr="//span[@t-field='line.price_subtotal']" position="attributes">
         <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
       </xpath>
@@ -83,7 +83,7 @@
         >
         <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
       </xpath>

--- a/sale_layout_category_hide_detail/views/sale_order_report_templates.xml
+++ b/sale_layout_category_hide_detail/views/sale_order_report_templates.xml
@@ -78,28 +78,28 @@
     <xpath expr="//td[@name='td_priceunit']/span" position="attributes">
       <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
     </xpath>
     <xpath expr="//td[@name='td_taxes']/span" position="attributes">
       <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
     </xpath>
     <xpath expr="//td[@name='td_subtotal']/span" position="attributes">
       <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
     </xpath>
     <xpath expr="//td[@t-if='display_discount']/span" position="attributes">
       <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
     </xpath>

--- a/sale_layout_category_hide_detail/views/sale_portal_templates.xml
+++ b/sale_layout_category_hide_detail/views/sale_portal_templates.xml
@@ -82,14 +82,21 @@
     <xpath expr="//div[@t-field='line.price_unit']" position="attributes">
         <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
+                separator=" and "
+            />
+      </xpath>
+    <xpath expr="//t[contains(@t-out, 'line.price_unit')]" position="attributes">
+        <attribute
+                name="t-if"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
       </xpath>
       <xpath expr="//span[@t-field='line.price_subtotal']" position="attributes">
         <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
       </xpath>
@@ -99,7 +106,7 @@
         >
         <attribute
                 name="t-if"
-                add="not current_section or current_section.show_line_amount"
+                add="(not current_section or current_section.show_line_amount)"
                 separator=" and "
             />
       </xpath>


### PR DESCRIPTION
Installing this module alongside a custom module of our own we noticed it failed.
The cause of this was a few instances of the following:
```xml
<attribute
    name="t-if"
    add="not current_section or current_section.show_line_amount"
    separator=" and "
 />
```
Though these show foresight they also lack parentheses around the epxression, if applied to an element that already has a `t-if` this forms an illogical expression with erroneous results.
e.g. `hide_discount and not current_section or current_section.show_line_amount`
causes an Exception when `hide_discount` is False and `current_section` is None, I hope you can see why.

Additionally, while fixing this I noticed there was a unit price displayed in the sale portal layout when a line is discounted, that wasn't being hidden when it should have been, an extra rule was added for that case.