### PR TITLE
[16.0][IMP] sale_report_delivered: Allow salesman to have access to the sale delivery report in the same way as they have access to the sales report.

### DIFF
--- a/sale_report_delivered/__manifest__.py
+++ b/sale_report_delivered/__manifest__.py
@@ -11,5 +11,9 @@
     "installable": True,
     "development_status": "Beta",
     "maintainers": ["sergio-teruel"],
-    "data": ["security/ir.model.access.csv", "views/sale_report_delivered_views.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "security/sale_report_security.xml",
+        "views/sale_report_delivered_views.xml",
+    ],
 }

--- a/sale_report_delivered/security/ir.model.access.csv
+++ b/sale_report_delivered/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sale_report_delivered_manager,sale.report.delivered,model_sale_report_delivered,sales_team.group_sale_manager,1,1,1,1
+access_sale_report_delivered_salesman,sale.report.delivered,model_sale_report_delivered,sales_team.group_sale_salesman,1,0,0,0

--- a/sale_report_delivered/security/sale_report_security.xml
+++ b/sale_report_delivered/security/sale_report_security.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_report_delivered_personal_rule" model="ir.rule">
+        <field name="name">Personal Delivered Analysis</field>
+        <field name="model_id" ref="model_sale_report_delivered" />
+        <field
+            name="domain_force"
+        >['|',('user_id','=',user.id),('user_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
+    </record>
+
+    <record id="sale_report_delivered_see_all_rule" model="ir.rule">
+        <field name="name">All Delivered Analysis</field>
+        <field name="model_id" ref="model_sale_report_delivered" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field
+            name="groups"
+            eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"
+        />
+    </record>
+</odoo>


### PR DESCRIPTION
fw port of https://github.com/OCA/sale-reporting/pull/297

cc @Tecnativa TT51606

@carlosdauden @pedrobaeza please review