### PR TITLE
[16.0][FIX] sale_layout_category_hide_detail: Post-install test + fallback to load CoA

### DIFF
--- a/sale_layout_category_hide_detail/tests/test_sale_layout_category_hide_detail.py
+++ b/sale_layout_category_hide_detail/tests/test_sale_layout_category_hide_detail.py
@@ -11,6 +11,15 @@ class TestSaleLayoutCategoryHideDetail(SaleCommon):
     @classmethod
     def setUpClass(cls):
         super(TestSaleLayoutCategoryHideDetail, cls).setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.product = cls.env["product.product"].create(
             {"name": "Producto test", "type": "consu", "invoice_policy": "order"}
         )


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa