### PR TITLE
[FIX] [16.0] sale_report_delivered: Fix unsigned_price_subtotal and unsigned_product_uom_qty using Valuation Layer Quantity first

### DIFF
--- a/sale_report_delivered/reports/sale_report.py
+++ b/sale_report_delivered/reports/sale_report.py
@@ -151,10 +151,15 @@ class SaleReportDeliverd(models.Model):
               {sub_select_signed_qty}
               ELSE 0
             END AS signed_qty,
-            (CASE WHEN t.type IN ('product', 'consu') THEN COALESCE(sm.product_uom_qty, 0.0)
-                ELSE sol.product_uom_qty END) / u.factor *
-                u2.factor as unsigned_product_uom_qty,
-            ROUND(COALESCE(sm.product_uom_qty * sol.price_reduce, sol.price_subtotal) /
+            (CASE
+                WHEN t.type IN ('product', 'consu')
+                THEN COALESCE(-svl.quantity, sm.product_uom_qty, 0.0)
+                ELSE sol.product_uom_qty END
+            ) / u.factor * u2.factor as unsigned_product_uom_qty,
+            ROUND(COALESCE(
+                -svl.quantity * sol.price_reduce,
+                sm.product_uom_qty * sol.price_reduce,
+                sol.price_subtotal) /
                 CASE COALESCE(s.currency_rate, 0)
                     WHEN 0 THEN 1.0 ELSE s.currency_rate END, cur.decimal_places)
                      as unsigned_price_subtotal,


### PR DESCRIPTION
When [revaluation of Valuation Layers happens](https://github.com/odoo/odoo/blob/16.0/addons/stock_account/models/product.py#L486-L496), another valuation is created linked to the Stock Move and the report lines were duplicated.  

This is what happens when a Reevaluation is triggered:
![image](https://github.com/user-attachments/assets/ad48812f-e131-43b2-b8f0-3c862353002e)

BEFORE / AFTER:
![image](https://github.com/user-attachments/assets/e86745e9-4513-4323-b094-dda0c40998ac)

Using the quantity on the Valuation Layer (if exists) before taking product_uom_qty, adjust the real Quantity delivered and Price delivered on each Valuation Layer line of the report.

**What has been changed:**
- -`svl.quantity` on COALESCE of unsigned_product_uom_qty 
- `-svl.quantity * sol.price_reduce` on first operand of COALESCE of unsigned_price_subtotal 

MT-9336 @moduon @rafaelbn @yajo @Gelojr @fcvalgar @sergio-teruel please review if you want 😄 