### PR TITLE
[17.0][FIX] sale_quotation_builder: Prevent issue with templates in multi-company environments

### DIFF
--- a/sale_quotation_builder/data/sale_order_template_data.xml
+++ b/sale_quotation_builder/data/sale_order_template_data.xml
@@ -5,7 +5,7 @@
         <record id="sale_order_template_default" model="sale.order.template">
             <field name="name">Default Template</field>
             <field name="number_of_days">30</field>
-
+            <field name="company_id" eval="False" />
             <field name="website_description" type="html">
                 <section data-snippet-id="title" class="mt32">
                     <h2 class="o_page_header">About us</h2>


### PR DESCRIPTION
After this commit https://github.com/odoo/odoo/commit/33fd2b1b2efcfa73ba8dc14f3d157cb0d76bb6d6, sale templates have the current company as default. When installing this module in a database with a multi-company environment and running `_set_default_sale_order_template_id_if_empty`, a multi-company issue is raised (`Incompatible companies on records`). This commit prevents the issue by keeping the company field empty in the default template.

@Tecnativa @pilarvargas-tecnativa @victoralmau @pedrobaeza could you please review this?