### PR TITLE
[18.0][FIX] sale_order_report_product_image: show the image in PDF

### DIFF
--- a/sale_order_report_product_image/views/report_saleorder.xml
+++ b/sale_order_report_product_image/views/report_saleorder.xml
@@ -10,7 +10,7 @@
         <td name="td_name" position="before">
             <td name="td_image">
                 <span
-                    t-field="line.product_id.image_128"
+                    t-esc="line.product_id.image_128"
                     t-options="{'widget': 'image', 'max_width': '64', 'class': 'rounded'}"
                 />
             </td>


### PR DESCRIPTION
Fix the problem reported in Issue #333  