### PR TITLE
[18.0][FIX] sale_order_line_position: possible null position

### DIFF
--- a/sale_order_line_position/models/sale_order_line.py
+++ b/sale_order_line_position/models/sale_order_line.py
@@ -37,7 +37,7 @@ class SaleOrderLine(models.Model):
             ids = tuple(set(sale_ids))
             self.flush_model()
             query = """
-            SELECT order_id, max(position) FROM sale_order_line
+            SELECT order_id, coalesce(max(position), 0) FROM sale_order_line
             WHERE order_id in %s GROUP BY order_id;
             """
             self.env.cr.execute(query, (ids,))


### PR DESCRIPTION
The position field is not required, so technically it could exists a sale order line row with a NULL position value.

In that case the computation of the next position number will fail with

    unsupported operand type(s) for +: 'NoneType' and 'int'

This change makes sure to not have a crash in such case.