### PR TITLE
[16.0][FIX] sale_order_report_product_image: allow showing images in portal reports

### DIFF
--- a/sale_order_report_product_image/views/report_saleorder.xml
+++ b/sale_order_report_product_image/views/report_saleorder.xml
@@ -10,9 +10,12 @@
         </th>
         <td name="td_name" position="before">
             <td name="td_image">
-                <span
-                    t-field="line.product_id.image_128"
-                    t-options="{'widget': 'image', 'max_width': '64', 'class': 'rounded'}"
+                <img
+                    t-if="line.product_id.image_128"
+                    t-att-src="image_data_uri(line.product_id.image_128)"
+                    style="max-width: 64px;"
+                    class="rounded"
+                    alt="Product image"
                 />
             </td>
         </td>


### PR DESCRIPTION
Using t-field does not allow loading image for portal users when they click "Download" button in portal.


EDIT: pre-commit error not related to this PR