### PR TITLE
[16.0][FIX] sale_report_delivered: aggregate SVLs by stock move

### DIFF
--- a/sale_report_delivered/reports/sale_report.py
+++ b/sale_report_delivered/reports/sale_report.py
@@ -207,7 +207,14 @@ class SaleReportDeliverd(models.Model):
             stock_location dest_location ON sm.location_dest_id = dest_location.id
         LEFT JOIN
             stock_location source_location ON sm.location_id = source_location.id
-        LEFT JOIN stock_valuation_layer svl ON svl.stock_move_id = sm.id
+        LEFT JOIN (
+            SELECT
+                stock_move_id,
+                SUM(quantity) AS quantity,
+                SUM(value) AS value
+            FROM stock_valuation_layer
+            GROUP BY stock_move_id
+        ) svl ON svl.stock_move_id = sm.id
         LEFT JOIN stock_picking sp ON sp.id = sm.picking_id
         LEFT JOIN res_currency as cur ON cur.id = sol.currency_id
         """

--- a/sale_report_delivered/tests/test_sale_report_delivered.py
+++ b/sale_report_delivered/tests/test_sale_report_delivered.py
@@ -96,3 +96,19 @@ class TestSaleReportDelivered(TestSaleReportDeliveredBase):
     @users("test_user-sale_report_delivered")
     def test_sale_report_delivered_read_group(self):
         self._test_sale_report_delivered_read_group()
+
+    def test_sale_report_delivered_uses_net_svl_quantity(self):
+        move = self.order_1.order_line.move_ids
+        item = self.env["sale.report.delivered"].search(
+            [("product_id", "=", self.product.id), ("order_id", "=", self.order_1.id)]
+        )
+        self.assertAlmostEqual(item.product_uom_qty, 1)
+        self.assertEqual(len(move.stock_valuation_layer_ids), 1)
+        move.move_line_ids.qty_done = 0.5
+        # The user modifies the done ml and an adjustment layer is made
+        self.assertEqual(len(move.stock_valuation_layer_ids), 2)
+        self.env.invalidate_all()
+        item = self.env["sale.report.delivered"].search(
+            [("product_id", "=", self.product.id), ("order_id", "=", self.order_1.id)]
+        )
+        self.assertAlmostEqual(item.product_uom_qty, 0.5)


### PR DESCRIPTION
Aggregate svls by stock move before joining them. A single move can generate multiple valuation layers after corrections, and joining them row by row makes the report sum absolute quantities instead of the net delivered quantity.


How do we come to this situation? Well, apparently a user can change the move line done quantity from the move line form that can be accessed from the *Inventory dashboard > [operation type]  >(three dots menu) > Operations*.

@moduon MT-14369


please review @Shide 