### PR TITLE
[17.0][FIX] sale_order_report_product_image: use higher resolution image for WebP compatibility

### DIFF
--- a/sale_order_report_product_image/views/report_saleorder.xml
+++ b/sale_order_report_product_image/views/report_saleorder.xml
@@ -11,7 +11,7 @@
         <td name="td_name" position="before">
             <td name="td_image">
                 <span
-                    t-field="line.product_id.image_128"
+                    t-field="line.product_id.image_1920"
                     t-options="{'widget': 'image', 'max_width': '64', 'class': 'rounded'}"
                 />
             </td>


### PR DESCRIPTION
Use image_1920 instead of image_128 in sale order reports. image_128 may fail to render in PDF when using WebP images, while higher resolutions display correctly.

Before:

<img width="691" height="141" alt="image" src="https://github.com/user-attachments/assets/28b267e4-1cf1-4159-b291-1922ee1bbe18" />


After:

<img width="692" height="159" alt="image" src="https://github.com/user-attachments/assets/1838f5a5-354f-4f0e-b8a5-5613cb664262" />

@Tecnativa TT62020

@pedrobaeza @juancarlosonate-tecnativa please review
