### PR TITLE
[17.0][FIX] sale_order_report_product_image: allow showing images in portal reports

### DIFF
--- a/sale_order_report_product_image/views/report_saleorder.xml
+++ b/sale_order_report_product_image/views/report_saleorder.xml
@@ -10,9 +10,12 @@
         </th>
         <td name="td_name" position="before">
             <td name="td_image">
-                <span
-                    t-field="line.product_id.image_128"
-                    t-options="{'widget': 'image', 'max_width': '64', 'class': 'rounded'}"
+                <img
+                    t-if="line.product_id.image_128"
+                    t-att-src="image_data_uri(line.product_id.image_128)"
+                    style="max-width: 64px;"
+                    class="rounded"
+                    alt="Product image"
                 />
             </td>
         </td>

--- a/sale_order_report_product_image/views/report_saleorder.xml
+++ b/sale_order_report_product_image/views/report_saleorder.xml
@@ -11,7 +11,7 @@
         <td name="td_name" position="before">
             <td name="td_image">
                 <span
-                    t-field="line.product_id.image_1920"
+                    t-field="line.product_id.image_128"
                     t-options="{'widget': 'image', 'max_width': '64', 'class': 'rounded'}"
                 />
             </td>


### PR DESCRIPTION
revert + fwp https://github.com/OCA/sale-reporting/pull/358

The fix introduced in #367 (using image_1920) worked in local testing but does not reliably solve the issue in all cases.

Further analysis showed that the problem is not related to the image resolution, but to how images are rendered in PDF reports.

This PR applies the approach in 16.0 (#358), replacing the use of the t-field image widget with a direct <img> tag, which ensures proper rendering of product images in PDF reports.

@Tecnativa TT62020

@pedrobaeza @juancarlosonate-tecnativa please review