### PR TITLE
[FIX] sale_layout_category_hide_detail: Fix show_line_amount

### DIFF
--- a/sale_layout_category_hide_detail/views/sale_order_report_templates.xml
+++ b/sale_layout_category_hide_detail/views/sale_order_report_templates.xml
@@ -89,6 +89,13 @@
                 separator=" and "
             />
         </xpath>
+        <xpath expr="//td[@name='td_priceunit']/span[@t-else]" position="attributes">
+            <attribute
+                name="t-if"
+                add="(not current_section or current_section.show_line_amount)"
+                separator=" and "
+            />
+        </xpath>
         <xpath expr="//td[@name='td_taxes']/span" position="attributes">
             <attribute
                 name="t-if"
@@ -97,6 +104,13 @@
             />
         </xpath>
         <xpath expr="//td[@name='td_subtotal']/span" position="attributes">
+            <attribute
+                name="t-if"
+                add="(not current_section or current_section.show_line_amount)"
+                separator=" and "
+            />
+        </xpath>
+        <xpath expr="//td[@name='td_subtotal']/span[@t-else]" position="attributes">
             <attribute
                 name="t-if"
                 add="(not current_section or current_section.show_line_amount)"

--- a/sale_layout_category_hide_detail/views/sale_portal_templates.xml
+++ b/sale_layout_category_hide_detail/views/sale_portal_templates.xml
@@ -101,6 +101,13 @@
                 separator=" and "
             />
         </xpath>
+        <xpath expr="//span[@t-field='line.price_total']" position="attributes">
+            <attribute
+                name="t-if"
+                add="(not current_section or current_section.show_line_amount)"
+                separator=" and "
+            />
+        </xpath>
         <xpath
             expr="//t[@t-foreach='lines_to_report']//span[contains(@t-out, 'line.tax_id')]"
             position="attributes"


### PR DESCRIPTION
Odoo added a <span t-else> element in td_priceunit and td_subtotal in Sale Order PDF and portal template, which made the xpath no longer work.