### PR TITLE
[UPD] sale_order_report_hide_tax: development_status from Alpha to Beta

### DIFF
--- a/sale_order_report_hide_tax/README.rst
+++ b/sale_order_report_hide_tax/README.rst
@@ -14,9 +14,9 @@ Sale order line hide tax in report
    !! source digest: sha256:461eccd06e840a9dd6a82ddbcfce25e5f5b6434130c11bd69f90dfcc59cb9997
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-.. |badge1| image:: https://img.shields.io/badge/maturity-Alpha-red.png
+.. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
-    :alt: Alpha
+    :alt: Beta
 .. |badge2| image:: https://img.shields.io/badge/license-LGPL--3-blue.png
     :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
     :alt: License: LGPL-3
@@ -36,11 +36,6 @@ Hide taxes column in the quotation document that is sent to the
 customer. When all quotation lines have the same tax group, the Taxes
 column is automatically hidden to avoid displaying redundant information
 and to improve document clarity.
-
-.. IMPORTANT::
-   This is an alpha version, the data model and design can change at any time without warning.
-   Only for development or testing purpose, do not use in production.
-   `More details on development status <https://odoo-community.org/page/development-status>`_
 
 **Table of contents**
 

--- a/sale_order_report_hide_tax/__manifest__.py
+++ b/sale_order_report_hide_tax/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Sale order line hide tax in report",
     "summary": "Hide taxes column when they don't add value",
     "version": "19.0.1.0.0",
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-reporting",
     "author": "Moduon, Odoo Community Association (OCA)",

--- a/sale_order_report_hide_tax/static/description/index.html
+++ b/sale_order_report_hide_tax/static/description/index.html
@@ -374,17 +374,11 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:461eccd06e840a9dd6a82ddbcfce25e5f5b6434130c11bd69f90dfcc59cb9997
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-reporting/tree/19.0/sale_order_report_hide_tax"><img alt="OCA/sale-reporting" src="https://img.shields.io/badge/github-OCA%2Fsale--reporting-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-reporting-19-0/sale-reporting-19-0-sale_order_report_hide_tax"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-reporting&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-reporting/tree/19.0/sale_order_report_hide_tax"><img alt="OCA/sale-reporting" src="https://img.shields.io/badge/github-OCA%2Fsale--reporting-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-reporting-19-0/sale-reporting-19-0-sale_order_report_hide_tax"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-reporting&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>Hide taxes column in the quotation document that is sent to the
 customer. When all quotation lines have the same tax group, the Taxes
 column is automatically hidden to avoid displaying redundant information
 and to improve document clarity.</p>
-<div class="admonition important">
-<p class="first admonition-title">Important</p>
-<p class="last">This is an alpha version, the data model and design can change at any time without warning.
-Only for development or testing purpose, do not use in production.
-<a class="reference external" href="https://odoo-community.org/page/development-status">More details on development status</a></p>
-</div>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
As this module has been migrated in this `19.0` I suppose it could be upgraded from `Alpha` to `Beta`.